### PR TITLE
Added few more info to readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,19 @@ nuttyapp
 ========
 This repo is the angular browser/client side code. Server side REST api is in nuttyrest repo.
 
+How do I install?
+==================
+
+Install the chrome [plugin](https://chrome.google.com/webstore/detail/ooelecakcjobkpmbdnflfneaalbhejmk)
+
+In your terminal :
+
+```
+$ curl https://nutty.io/install_host.sh | sudo bash
+```
+And then visit [nutty.io](https://nutty.io/home)
+
+That's it, enjoy using nutty! :)
 
 LICENSE
 =======


### PR DESCRIPTION
We could use `curl https://nutty.io/install_host.sh | sudo bash`
