### PR TITLE
Fixes to nutty.py and install_host.sh

### DIFF
--- a/install_host.sh
+++ b/install_host.sh
@@ -34,6 +34,11 @@ curl https://nutty.io/$HOST_NAME.json > $MANIFEST_DIR/$HOST_NAME.json
 curl https://nutty.io/nutty.py > $SCRIPT_DIR/nutty.py
 chmod +x $SCRIPT_DIR/nutty.py
 
+# Update host path in the manifest.
+HOST_PATH=$SCRIPT_DIR/nutty.py
+ESCAPED_HOST_PATH=${HOST_PATH////\\/}
+sed -i -e "s/HOST_PATH/$ESCAPED_HOST_PATH/" $MANIFEST_DIR/$HOST_NAME.json
+
 # Set permissions for the manifest so that all users can read it.
 chmod o+r $MANIFEST_DIR/$HOST_NAME.json
 

--- a/io.nutty.terminal.json
+++ b/io.nutty.terminal.json
@@ -4,7 +4,7 @@
 {
   "name": "io.nutty.terminal",
   "description": "nutty.io - Securely share terminals over web using browser",
-  "path": "/opt/nutty/nutty.py",
+  "path": "HOST_PATH",
   "type": "stdio",
   "allowed_origins": [
     "chrome-extension://ooelecakcjobkpmbdnflfneaalbhejmk/"


### PR DESCRIPTION
- nutty.py has been modified to make it work with both python 2 and python 3.
- install_host.sh now installs the host script into /opt/nutty on Linux systems
